### PR TITLE
Sub-TextureRegion

### DIFF
--- a/EzySlice/Framework/TextureRegion.cs
+++ b/EzySlice/Framework/TextureRegion.cs
@@ -105,10 +105,10 @@ namespace EzySlice {
             int calcX = Mathf.Min(Mathf.Abs(pixX), textureWidth);
             int calcY = Mathf.Min(Mathf.Abs(pixY), textureHeight);
 
-            float startX = calcX / textureWidth;
-            float startY = calcY / textureHeight;
-            float endX = (calcX + calcWidth) / textureWidth;
-            float endY = (calcY + calcHeight) / textureHeight;
+            float startX = calcX / (float)textureWidth;
+            float startY = calcY / (float)textureHeight;
+            float endX = (calcX + calcWidth) / (float)textureWidth;
+            float endY = (calcY + calcHeight) / (float)textureHeight;
 
             // texture region is a struct which is allocated on the stack
             return new TextureRegion(startX, startY, endX, endY);


### PR DESCRIPTION
Currently, when creating a slice with a supplied TextureRegion that is not the entire texture space, the texture won't be mapped correctly and will instead use the pixel colour at 0,0.

This pull request fixes that issue and a few others that became apparent afterward. The sub-texture region was incorrect due to integer division in the TextureRegion constructor. Once that was working I realized that the texture wasn't mapping as expected and made some changes to make sure the selected region maps as tightly as possible to the newly generated faces. Once that was complete, for some reason the texture was being projected correctly only when the object/plane were not rotated.  I changed the basis vectors for the mapping of the 3D intersection points to 2D uvs to be a bit more consistent.

I also tabbified the documents I edited for consistency.