### PR TITLE
Intersection rounding

### DIFF
--- a/EzySlice/Framework/Plane.cs
+++ b/EzySlice/Framework/Plane.cs
@@ -87,7 +87,7 @@ namespace EzySlice {
 				return SideOfPlane.UP;
 			}
 
-            if (result < float.Epsilon) {
+            if (result < -float.Epsilon) {
 				return SideOfPlane.DOWN;
 			}
 

--- a/EzySlice/Framework/Triangulator.cs
+++ b/EzySlice/Framework/Triangulator.cs
@@ -155,8 +155,6 @@ namespace EzySlice {
 			// ensure List does not dynamically grow, performing copy ops each time!
 			tri = new List<Triangle>(triCount / 3);
 
-			float maxDiv = Mathf.Max(maxDivX, maxDivY);
-
 			float width = maxDivX - minDivX;
 			float height = maxDivY - minDivY;
 


### PR DESCRIPTION
Fixes a warning casued by an unused variable (pushed in my previous pull request, sorry!).
Fixes a rounding error in the plane-vector side test where Epsilon should be negative for the lower bound.