### PR TITLE
SliceInstantiate in transforms can cause problems

### DIFF
--- a/EzySlice/SlicedHull.cs
+++ b/EzySlice/SlicedHull.cs
@@ -23,6 +23,7 @@ namespace EzySlice {
 
         public GameObject CreateUpperHull(GameObject original, Material crossSectionMat) {
             GameObject newObject = CreateUpperHull();
+            newObject.transform.parent = original.transform.parent;
 
             if (newObject != null) {
                 newObject.transform.localPosition = original.transform.localPosition;
@@ -62,6 +63,7 @@ namespace EzySlice {
 
         public GameObject CreateLowerHull(GameObject original, Material crossSectionMat) {
             GameObject newObject = CreateLowerHull();
+            newObject.transform.parent = original.transform.parent;
 
             if (newObject != null) {
                 newObject.transform.localPosition = original.transform.localPosition;


### PR DESCRIPTION
When you create the newObject, it copies the local position, rotation and scale of the original object, which is all fine, however, if the object itself is inside a transform with a position, rotation or scale that isn't the default one, it can cause some problems. It cam be fixed by simply assigning the same parent to the newObject.

You could argue that it wouldn't be necessary to do that if instead of using local position and rotation you used the global one, however, the scale is still a problem. 

I was stuck trying to figure out why the sliced parts teleported through the map and it turned out to be this. I am sure this is a very hacky way of fixing this, but it worked for me, and hey, if it turns out to be a good solution, then perfect!

Leaving that aside, the slicing scripts work like a charm, thanks a lot for writing this!