### PR TITLE
Fixed index format

### DIFF
--- a/EzySlice/Slicer.cs
+++ b/EzySlice/Slicer.cs
@@ -296,7 +296,8 @@ namespace EzySlice {
             int crossCount = crossSection != null ? crossSection.Count : 0;
 
             Mesh newMesh = new Mesh();
-
+            newMesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            
             int arrayLen = (total + crossCount) * 3;
 
             bool hasUV = meshes[0].hasUV;


### PR DESCRIPTION
Mesh.indexFormat by default is 16 bit which is not enough for large polygon models and it was changed to 32 bit.